### PR TITLE
Update for resource type and resource attribute header.

### DIFF
--- a/theme.tres
+++ b/theme.tres
@@ -1,3 +1,6 @@
+[gd_resource type="EditorSettings" format=2]
+
+[resource]
 interface/theme/preset = "Custom"
 interface/theme/base_color = Color( 0.156863, 0.164706, 0.211765, 1 )
 interface/theme/accent_color = Color( 0.741176, 0.576471, 0.976471, 1 )


### PR DESCRIPTION
I needed to add these to get the theme to work with Godot v3.2.2. Otherwise Godot would over write the settings file.